### PR TITLE
return json response from deleting a cake.

### DIFF
--- a/app/controllers/api/v1/cakes_controller.rb
+++ b/app/controllers/api/v1/cakes_controller.rb
@@ -28,7 +28,6 @@ module Api
       def destroy
         @cake = current_user.creations.find(params[:id])
         @cake.destroy!
-        render nothing: true
       end
 
       private

--- a/app/views/api/v1/cakes/destroy.json.jbuilder
+++ b/app/views/api/v1/cakes/destroy.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! 'cake', cake: @cake

--- a/spec/controllers/api/v1/cakes_controller_spec.rb
+++ b/spec/controllers/api/v1/cakes_controller_spec.rb
@@ -66,7 +66,7 @@ describe Api::V1::CakesController do
       end
 
       it "updates the description" do
-        new_story = "what's the haps on the craps"
+        new_story = "what is the haps on the craps"
         xhr :patch, :update, id: cake.id, cake: { story: new_story }
 
         cake.reload
@@ -92,6 +92,11 @@ describe Api::V1::CakesController do
 
       it "deletes the specified cake" do
         expect(Creation.exists?(cake.id)).to be_falsey
+      end
+
+      it "returns an empty json response" do
+        json = JSON.parse(response.body)
+        expect(json["id"]).to eql(cake.id)
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
   factory :category, class: Category do
     name { Faker::Name.name }
-    slug { Faker::Name.name.gsub(/ /, "-").downcase }
+    slug { Faker::Name.name.parameterize }
   end
 
   factory :cake, class: Creation, aliases: [:creation] do

--- a/spec/models/creation/repository_spec.rb
+++ b/spec/models/creation/repository_spec.rb
@@ -47,8 +47,9 @@ describe Creation::Repository do
 
   context "#search_with" do
     let(:cake_category) { create(:category) }
-    let!(:cake) { create(:cake, category: cake_category) }
-    let!(:cookie) { create(:cake) }
+    let(:cookie_category) { create(:category) }
+    let!(:cake) { create(:cake, name: "cake", category: cake_category) }
+    let!(:cookie) { create(:cake, name: "cookie", category: cookie_category) }
 
     before :each do
       cake.photos << create(:photo)


### PR DESCRIPTION
Backbone expects a json response when an item is deleted. This is causing an issue when hiding the delete cake modal.
